### PR TITLE
Add filter ability for upcoming and past events

### DIFF
--- a/_posts/2015-02-01-opensourcedesign-fosdem.markdown
+++ b/_posts/2015-02-01-opensourcedesign-fosdem.markdown
@@ -6,6 +6,7 @@ categories: design hack meeting
 eventDate: Sun, 1 February 2015
 location: Université Libre Brussels (Solbosch campus), Belgium
 time: 9:00 – 16:45 CET (UTC +1:00)
+status: past
 ---
 
 [FOSDEM](https://fosdem.org) is one of the biggest open source conferences. For the first time this year, there will be a dedicated [Open Source Design track](https://fosdem.org/2015/schedule/track/open_source_design/)!

--- a/_posts/2015-03-15-berlin-open-source-design-meetup.markdown
+++ b/_posts/2015-03-15-berlin-open-source-design-meetup.markdown
@@ -6,6 +6,7 @@ categories: berlin meeting
 eventDate: Sun, 15 March 2015
 location: bnvk Haus/online
 time: 13:00–18:00 CET (UTC +1:00)
+status: past
 ---
 Let’s meet and work on driving the Open Soure Design movement forward! Everyone who wants to contribute is welcome.
 

--- a/_posts/2015-03-29-planning-meetup.markdown
+++ b/_posts/2015-03-29-planning-meetup.markdown
@@ -6,6 +6,7 @@ categories: planing meeting
 eventDate: Sun, 29 March 2015
 location: online
 time: 15:00–16:30 CET (UTC +1:00)
+status: past
 ---
 In our [last meetup](2015-03-15%20Berlin%20Open%20Source%20Design%20meetup.md) we outlined a bunch of good plans.
 

--- a/_posts/2015-04-25-designs-and-hacks.markdown
+++ b/_posts/2015-04-25-designs-and-hacks.markdown
@@ -6,6 +6,7 @@ categories: design hack meeting
 eventDate: Sat, 25 April 2015
 location: bnvk Haus/online
 time: 14:00 – 18:00 CET (UTC +1:00)
+status: past
 ---
 Lots of things that we've talking about for the last couple months. Time to push some pixels and code and breath life into these objective. Let’s meet and work on driving the Open Soure Design movement forward. Everyone who wants to contribute is welcome :)
 

--- a/_posts/2015-04-29-libregraphicsmeeting.markdown
+++ b/_posts/2015-04-29-libregraphicsmeeting.markdown
@@ -6,6 +6,7 @@ categories: design hack meeting
 eventDate: Tue, 29 April 2015 – Sat, 2 May 2015
 location: Toronto, Canada
 time: full days
+status: past
 ---
 
 The [Libre Graphics Meeting (LGM)](http://libregraphicsmeeting.org/2015/) is an annual meeting on free and open source software for graphics.

--- a/index.html
+++ b/index.html
@@ -6,37 +6,58 @@ layout: default
 
     <h1>Events</h1>
 
-    <ul class="post-list">
-        {% for post in site.posts %}
-        <li>
+    {% assign posts = site.posts | where: "status", "upcoming" %}
+    {% if posts != empty %}
+        <h3>Upcoming events</h3>
+        <ul class="post-list">
+            {% for post in posts %}
+            <li>
+                <h2>
+                    <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+                </h2>
 
+                {{ post.excerpt }}
+                <ul class="location">
+                    {% if post.eventDate %}
+                    <li>
+                        <strong>Date:</strong> {{ post.eventDate }}
+                    </li>
+                    {% endif %}
+                    {% if post.time %}
+                    <li>
+                        <strong>Time:</strong> {{ post.time }}
+                    </li>
+                    {% endif %}
+                    {% if post.location %}
+                    <li>
+                        <strong>Location:</strong> {{ post.location }}
+                    </li>
+                    {% endif %}
+                </ul>
+            </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <h2>There are no upcoming events</h2>
+        <p>To add an event <a href="https://github.com/opensourcedesign/events" target="_blank">fork and send a pull request</a></p>
+    {% endif %}
+
+    {% assign pastEvents = site.posts | where: "status", "past" %}
+    {% if pastEvents %}
+    <h3>Pasts events</h3>
+    <ul class="post-list">
+        {% for post in pastEvents %}
+        <li>
             <h2>
                 <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
             </h2>
-
             {{ post.excerpt }}
-            <ul class="location">
-                {% if post.eventDate %}
-                <li>
-                    <strong>Date:</strong> {{ post.eventDate }}
-                </li>
-                {% endif %}
-                {% if post.time %}
-                <li>
-                    <strong>Time:</strong> {{ post.time }}
-                </li>
-                {% endif %}
-                {% if post.location %}
-                <li>
-                    <strong>Location:</strong> {{ post.location }}
-                </li>
-                {% endif %}
-            </ul>
-
-
         </li>
         {% endfor %}
     </ul>
+    {% endif %}
+
+
 
     <p>To add an event <a href="https://github.com/opensourcedesign/events" target="_blank">fork and send a pull request</a></p>
 


### PR DESCRIPTION
Added a new attribute for the events, it could be either 'upcoming' or 'past'
If 'upcoming' shows title, excerpt, date, location..etc.
If 'past' shows only title and excerpt (i think it gives a basic information but we should be careful with the excerpt)

If no upcoming shows how to add an event.
