### PR TITLE
Correct submission date in the summary

### DIFF
--- a/_posts/2016-01-30-opensourcedesign-fosdem.markdown
+++ b/_posts/2016-01-30-opensourcedesign-fosdem.markdown
@@ -11,7 +11,7 @@ status: upcoming
 
 [FOSDEM](https://fosdem.org) is one of the biggest open source conferences. For the second time there will be a dedicated Open Source Design track.
 
-The call for participation is now open. Dead line for submitting your proposals is **December 1st 2015**
+The call for participation is now open. Dead line for submitting your proposals is **December 8th 2015**
 
 The full call for participation is below.
 


### PR DESCRIPTION
The submission date at the top of the page was still showing as 1st December, so changing it to the 8th to avoid any confusion.

Signed-off-by: Belen Barros Pena belen.barros.pena@linux.intel.com
