### PR TITLE
change status to "past" for "Foss North, Gothenberg" event

### DIFF
--- a/_posts/2017-04-06-foss-north.md
+++ b/_posts/2017-04-06-foss-north.md
@@ -6,7 +6,7 @@ categories: talk
 eventDate: April 26th, 2017
 location: Folkets hus, Gothenburg
 time: pending
-status: upcoming
+status: past
 permalink: /2017/02/04/foss-north-2017
 ---
 


### PR DESCRIPTION
I originally made noise about this at https://botbot.me/freenode/opensourcedesign/msg/89077714/