### PR TITLE
make URLs into links (autolinking not supported)

### DIFF
--- a/_posts/2017-10-13-open-source-design-summit-berlin.md
+++ b/_posts/2017-10-13-open-source-design-summit-berlin.md
@@ -13,7 +13,7 @@ We're organizing a summit for all designers and developers interested in cheerle
 
 October 13 is the arrival day with a social event in the evening. 14-15 are unconf days, 16-17 workshops/discussion, 18 is maybe brunch but also leaving day.
 
-Please see http://opensourcedesign.net/summit/ for more information and https://opencollective.com/opensourcedesign/events/opensourcedesign-summit to express interest in attending! You are also welcome to [join the conversation on GitHub](https://github.com/opensourcedesign/organization/issues?q=is%3Aissue+is%3Aopen+label%3Asummit).
+Please see <http://opensourcedesign.net/summit/> for more information and <https://opencollective.com/opensourcedesign/events/opensourcedesign-summit> to express interest in attending! You are also welcome to [join the conversation on GitHub](https://github.com/opensourcedesign/organization/issues?q=is%3Aissue+is%3Aopen+label%3Asummit).
 
 ## Date & Location
 


### PR DESCRIPTION
On the version at http://opensourcedesign.net/events/2017/10/open-source-design-summit-berlin the URLs aren't clickable.