### PR TITLE
Change past events to status: past

### DIFF
--- a/_posts/2017-11-09-open-source-design-nyc.md
+++ b/_posts/2017-11-09-open-source-design-nyc.md
@@ -6,7 +6,7 @@ categories: design meetup community
 eventDate: Thurs, 09 Nov 2017
 location: New York
 time: 6:00pm - 8.00pm (EDT)
-status: upcoming
+status: past
 ---
 
 Calling Open Source Design enthusiasts living in NYC and around to join us for our next meetup on open design toolkit. This will be a fun evening reviewing Jessica Klein's toolkit and discussion how it can/will help the design OS community.

--- a/_posts/2017-11-10-sfscon.md
+++ b/_posts/2017-11-10-sfscon.md
@@ -6,7 +6,7 @@ categories: talk
 eventDate: November 10th, 2017
 location: NOI Techpark, Bolzano (Italy)
 time: 12:30
-status: upcoming
+status: past
 permalink: /2017/11/10/sfscon-2017
 ---
 

--- a/_posts/2017-12-14-open-source-design-nyc.md
+++ b/_posts/2017-12-14-open-source-design-nyc.md
@@ -6,7 +6,7 @@ categories: design meetup community
 eventDate: Thurs, 14 Dec 2017
 location: New York
 time: 6:00pm - 8.00pm (EDT)
-status: upcoming
+status: past
 ---
 
 Calling Open Source Design enthusiasts living in NYC and around, please join us for our next meetup on looking at the intersection between accessibility, inclusive design, and open source. This will be given by [Atul Varma](https://twitter.com/toolness), who is known for building bridges of understanding between humans and machines. He has written illuminating software that's been used as the centerpiece of TED Talks, in maker events around the world, and by individuals who are just trying to have a less frustrating time using their computer. But his favorite moments are very personal: understanding where another person is coming from, constructing a metaphor they can relate to, and using it to explain technology in a way that liberates, excites, and empowers.


### PR DESCRIPTION
There needs to be a better mechanism for catching events by
passed dates and changing them appropriately.

It could be done with javascript, but adds a js dependency to
view the page correctly.

It could be coupled with a build-time method, but unless the site
is constantly built on a schedule (as opposed to a push on git)
this won't really fix it either.