### PR TITLE
Update monthly call page with link to forum

### DIFF
--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -12,9 +12,10 @@ permalink: /open-source-design-monthly-online-meeting/
 
 Join us for our monthly get together where we talk about all things Open Source Design. Everyone is welcome.
 
-To see what we talked about in previous meetings, check out the ["monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
+To see what we talked about in previous meetings, check out the ["Monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
-To get notifications of the monthly meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
+To get notifications of this meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
+
 
 ## Date & Location
 

--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -1,24 +1,20 @@
 ---
 layout: event
-title:  "Open Source Design Monthly Online Meeting"
+title:  "Open Source Design monthly call"
 date:   2018-07-04
 categories: online meet-up
 eventDate: Every First Wednesday
 location: Online at [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign)
-time:  7:00 PM to ... (Berlin Time)
+time:  19:00-20:00 (Berlin Time)
 status: upcoming
 permalink: /open-source-design-monthly-online-meeting/
 ---
 
 Join us for our monthly get together where we talk about all things Open Source Design. Everyone is welcome.
 
-To see what we talked about in previous meetings, look at:
+To see what we talked about in previous meetings, check out the ["monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
-[github.com/opensourcedesign/events/issues/49](https://github.com/opensourcedesign/events/issues/49)
-
-You can also subscribe to the calendar with this meeting in it as well as other related Open Source Design events:
-
-[cloud.nextcloud.com/apps/calendar/public/MIFAFLFJADIVX63I](https://cloud.nextcloud.com/apps/calendar/public/MIFAFLFJADIVX63I)
+You can also subscribe to the calendar with this meeting in it as well as other related Open Source Design events: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
 
 
 ## Date & Location
@@ -26,5 +22,5 @@ You can also subscribe to the calendar with this meeting in it as well as other 
 Our next event is:
 
 - **Date:** Wed, 4 July 2018
-- **Time:** 7:00 PM to ... (Berlin Time)
+- **Time:** 19:00 – 20:00 (Berlin Time)
 - **Where:** Online at [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign)

--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -14,8 +14,7 @@ Join us for our monthly get together where we talk about all things Open Source 
 
 To see what we talked about in previous meetings, check out the ["monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
-You can also subscribe to the calendar with this meeting in it as well as other related Open Source Design events: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
-
+To get notifications of the monthly meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
 
 ## Date & Location
 


### PR DESCRIPTION
Please review @ei8fdb @evalica @dmichl :)

I now moved all notes from the monthly calls we had on Github over to the forum at https://discourse.opensourcedesign.net/c/meta/monthly-call – slowly we’re migrating. :D