### PR TITLE
[Bug] Broken location URL

### DIFF
--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -4,7 +4,7 @@ title:  "Open Source Design monthly call"
 date:   2018-07-04
 categories: online meet-up
 eventDate: Every First Wednesday
-location: Online at [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign)
+location: Online
 time:  19:00-20:00 (Berlin Time)
 status: upcoming
 permalink: /open-source-design-monthly-online-meeting/

--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -12,17 +12,8 @@ permalink: /open-source-design-monthly-online-meeting/
 
 Join us for our monthly get together where we talk about all things Open Source Design. Everyone is welcome.
 
-These monthly meetings happen online, using Jitsi - [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign).
+These monthly meetings happen as a voice/video call using Jitsi at [meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign).
 
 To see what we talked about in previous meetings, check out the ["Monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
 To get notifications of this meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
-
-
-## Date & Location
-
-Our next event is:
-
-- **Date:** Wed, 4 July 2018
-- **Time:** 19:00 – 20:00 (Berlin Time)
-- **Where:** Online

--- a/osd-recurring-online-meeting.md
+++ b/osd-recurring-online-meeting.md
@@ -12,6 +12,8 @@ permalink: /open-source-design-monthly-online-meeting/
 
 Join us for our monthly get together where we talk about all things Open Source Design. Everyone is welcome.
 
+These monthly meetings happen online, using Jitsi - [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign).
+
 To see what we talked about in previous meetings, check out the ["Monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
 To get notifications of this meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
@@ -23,4 +25,4 @@ Our next event is:
 
 - **Date:** Wed, 4 July 2018
 - **Time:** 19:00 – 20:00 (Berlin Time)
-- **Where:** Online at [https://meet.jit.si/opensourcedesign](https://meet.jit.si/opensourcedesign)
+- **Where:** Online


### PR DESCRIPTION
The second Jitsi URL is broken, maybe because there is a different mechanism to add that table information. 

I've removed the link and kept only "Online", but there is some duplication on this page. 
Not really sure what is the best solution.

<img width="791" alt="url" src="https://user-images.githubusercontent.com/629552/41720684-7c5a4b08-756c-11e8-87fd-398d16f28e28.png">
