### PR TITLE
[misc] Adding the year as part of events titles

### DIFF
--- a/_posts/2017-04-06-foss-north.md
+++ b/_posts/2017-04-06-foss-north.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Foss North, Gothenberg"
+title:  "Foss North, Gothenberg 2017"
 date:   2017-04-26
 categories: talk
 eventDate: April 26th, 2017

--- a/_posts/2017-05-05-cssconf.md
+++ b/_posts/2017-05-05-cssconf.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Community space at CSSconf EU"
+title:  "Community space at CSSconf EU 2018"
 date:   2018-02-04
 categories: design meeting
 eventDate: Fri, 5 May 2017

--- a/_posts/2017-05-06-g23.md
+++ b/_posts/2017-05-06-g23.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Open Source Design intro at G23 conference"
+title:  "Open Source Design intro at G23 conference 2017"
 date:   2017-05-06
 categories: design meeting
 eventDate: Sat, 6 May 2017

--- a/_posts/2017-05-25-opentechsummit.md
+++ b/_posts/2017-05-25-opentechsummit.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Open Source Design track at OpenTechSummit"
+title:  "Open Source Design track at OpenTechSummit 2017"
 date:   2017-05-25
 categories: design conference track
 eventDate: Sun, 4 Feb 2018

--- a/_posts/2017-06-01-open-source-design-event-madrid.md
+++ b/_posts/2017-06-01-open-source-design-event-madrid.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title: "Open Source Design Event Madrid"
+title: "Open Source Design Event Madrid 2017"
 date: 2017-06-01
 categories: design meetup community
 eventDate: Wed, 31 May 2017

--- a/_posts/2017-09-27-open-source-design-nyc.md
+++ b/_posts/2017-09-27-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: Sep 27"
+title:  "Open Source Design NYC: Sep 27 2017"
 date:   2017-09-27
 categories: design meetup community
 eventDate: Wed, 27 Sep 2017

--- a/_posts/2017-10-13-open-source-design-summit-berlin.md
+++ b/_posts/2017-10-13-open-source-design-summit-berlin.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design Summit 2017: Berlin, Oct 13-18"
+title:  "Open Source Design Summit: Berlin, Oct 13-18 2017"
 date:   2017-10-13
 categories: design meetup community
 eventDate: Fri, 13 Oct 2017 - Wed, 18 Oct 2017

--- a/_posts/2017-11-09-open-source-design-nyc.md
+++ b/_posts/2017-11-09-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: Nov 09"
+title:  "Open Source Design NYC: Nov 09 2017"
 date:   2017-11-09
 categories: design meetup community
 eventDate: Thurs, 09 Nov 2017

--- a/_posts/2017-11-10-sfscon.md
+++ b/_posts/2017-11-10-sfscon.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title: "Talk on Design-driven Free Software at SFScon Bolzano"
+title: "Talk on Design-driven Free Software at SFScon Bolzano 2017"
 date: 2017-11-10
 categories: talk
 eventDate: November 10th, 2017

--- a/_posts/2017-12-14-open-source-design-nyc.md
+++ b/_posts/2017-12-14-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: Dec 14"
+title:  "Open Source Design NYC: Dec 14 2017"
 date:   2017-12-14
 categories: design meetup community
 eventDate: Thurs, 14 Dec 2017

--- a/_posts/2018-01-18-open-source-design-nyc.md
+++ b/_posts/2018-01-18-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: Jan 18"
+title:  "Open Source Design NYC: Jan 18 2018"
 date:   2018-01-18
 categories: design meetup community
 eventDate: Thurs, 18 Jan 2018

--- a/_posts/2018-02-04-fosdem.md
+++ b/_posts/2018-02-04-fosdem.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title: "Fosdem 2018: Open Source Design devroom"
+title: "Open Source Design track at FOSDEM 2018"
 date: 2018-02-04
 categories: design hack meeting
 eventDate: Sun, 4 Feb 2018

--- a/_posts/2018-02-26-open-source-design-nyc.md
+++ b/_posts/2018-02-26-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: Feb 26"
+title:  "Open Source Design NYC: Feb 26 2018"
 date:   2018-02-26
 categories: design meetup community
 eventDate: Mon, 26 Feb 2018

--- a/_posts/2018-03-09-libre-graphics-track-scale.md
+++ b/_posts/2018-03-09-libre-graphics-track-scale.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title: "Libre Graphics Track at Southern California Linux Expo (SCaLE)"
+title: "Libre Graphics Track at Southern California Linux Expo (SCaLE) 2018"
 date: 2018-03-09
 categories: design hack meeting graphics
 eventDate: Fri, 9 Mar 2018

--- a/_posts/2018-05-24-open-source-design-nyc.md
+++ b/_posts/2018-05-24-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: May 24"
+title:  "Open Source Design NYC: May 24 2018"
 date:   2018-05-24
 categories: design meetup community
 eventDate: Thu, 24 May 2018

--- a/_posts/2018-07-12-open-source-design-nyc.md
+++ b/_posts/2018-07-12-open-source-design-nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: event
-title:  "Open Source Design NYC: July 12"
+title:  "Open Source Design NYC: July 12 2018"
 date:   2018-07-12
 categories: design meetup community
 eventDate: Thu, 12 July 2018


### PR DESCRIPTION
- Since there are some recurrent events that we do every year, plus to be consistent with the other events entries

- Before: 
<img width="802" alt="before" src="https://user-images.githubusercontent.com/629552/42312637-82a80e90-8049-11e8-9208-117390c222ba.png">

- After: 
<img width="800" alt="after" src="https://user-images.githubusercontent.com/629552/42312698-af00b104-8049-11e8-9ecf-7dc107384384.png">
